### PR TITLE
Construct from Date and Time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnixTimes"
 uuid = "ab1a18e7-b408-4913-896c-624bb82ed7f4"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnixTimes"
 uuid = "ab1a18e7-b408-4913-896c-624bb82ed7f4"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/UnixTimes.jl
+++ b/src/UnixTimes.jl
@@ -61,6 +61,8 @@ function UnixTime(x::DateTime)
 end
 
 UnixTime(x::Date) = UnixTime(DateTime(x))
+UnixTime(x::Date, y::Time) =
+    UnixTime(year(x), month(x), day(x), hour(y), minute(y), second(y), millisecond(y), microsecond(y), nanosecond(y))
 
 Base.convert(::Type{UnixTime}, x::DateTime) = UnixTime(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,7 @@ end
     @test Date(UnixTime(2020, 1, 2, 3)) == Date(2020, 1, 2)
     @test Time(UnixTime(2020, 1, 2, 3, 4, 5, 6, 7, 8)) == Time(3, 4, 5, 6, 7, 8)
     @test UnixTime(Date(2020, 1, 2)) == UnixTime(2020, 1, 2)
+    @test UnixTime(Date(2020, 1, 2), Time(3, 4, 5, 6, 7, 8)) == UnixTime(2020, 1, 2, 3, 4, 5, 6, 7, 8)
     @test convert(UnixTime, DateTime(2020, 1, 2, 3)) == UnixTime(2020, 1, 2, 3)
     @test convert(DateTime, UnixTime(2020, 1, 2, 3)) == DateTime(2020, 1, 2, 3)
     @test UnixTime(ZonedDateTime(2020, 1, 2, 3, tz"UTC-4")) == UnixTime(2020, 1, 2, 7)


### PR DESCRIPTION
`DateTime` only has millisecond precision so I opted for unwrapping the `Date` and `Time` rather than building a `DateTime` and converting that to `UnixTime`.