### PR TITLE
Move TimeZones dependency into an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,23 @@
 name = "UnixTimes"
 uuid = "ab1a18e7-b408-4913-896c-624bb82ed7f4"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-julia = "1"
-TimeZones = "1"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TimeZones"]
+
+[weakdeps]
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+
+[extensions]
+UnixTimesTimeZonesExt = "TimeZones"

--- a/ext/UnixTimesTimeZonesExt.jl
+++ b/ext/UnixTimesTimeZonesExt.jl
@@ -1,0 +1,11 @@
+module UnixTimesTimeZonesExt
+
+using Dates
+using TimeZones
+using UnixTimes
+
+UnixTimes.UnixTime(x::ZonedDateTime) = UnixTime(DateTime(x, UTC))
+TimeZones.ZonedDateTime(x::UnixTime, tz::TimeZone) =
+    ZonedDateTime(DateTime(x), tz; from_utc = true)
+
+end

--- a/src/UnixTimes.jl
+++ b/src/UnixTimes.jl
@@ -1,7 +1,6 @@
 module UnixTimes
 
 using Dates
-using TimeZones
 
 export UnixTime
 export unix_now
@@ -65,9 +64,6 @@ UnixTime(x::Date, y::Time) =
     UnixTime(year(x), month(x), day(x), hour(y), minute(y), second(y), millisecond(y), microsecond(y), nanosecond(y))
 
 Base.convert(::Type{UnixTime}, x::DateTime) = UnixTime(x)
-
-UnixTime(x::ZonedDateTime) = UnixTime(DateTime(x, UTC))
-ZonedDateTime(x::UnixTime, tz::TimeZone) = ZonedDateTime(DateTime(x), tz; from_utc = true)
 
 function Base.show(io::IO, x::UnixTime)
     xdt = convert(DateTime, x)


### PR DESCRIPTION
TimeZones is a relatively heavy dependency. This commit avoid adding it by default.