### PR TITLE
Cake duke patch 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnixTimes"
 uuid = "ab1a18e7-b408-4913-896c-624bb82ed7f4"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/UnixTimes.jl
+++ b/src/UnixTimes.jl
@@ -81,7 +81,7 @@ function Base.floor(x::UnixTime, p::Union{DatePeriod, TimePeriod})
     convert(UnixTime, floor(convert(DateTime, x), p))
 end
 
-Dates.guess(a::UnixTime, b::UnixTime, c) = guess(DateTime(a), DateTime(b), c)
+Dates.guess(a::UnixTime, b::UnixTime, c) = Dates.guess(DateTime(a), DateTime(b), c)
 
 Dates.default_format(::Type{UnixTime}) = nothing
 Dates.format(x::UnixTime, fmt::Nothing) = string(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,4 +91,11 @@ end
     @test ZonedDateTime(UnixTime(2020, 1, 2, 7), tz"UTC-4") == ZonedDateTime(2020, 1, 2, 3, tz"UTC-4")
 end
 
+@testset "collect" begin
+    t1 = UnixTime(2024,7,18,10,0,0)
+    t2 = UnixTime(2024,7,18,10,0,10)
+    p = Millisecond(100)
+    @test collect(t1:p:t2) isa Vector
+end
+
 end


### PR DESCRIPTION
Collect throws

```julia
t1 = UnixTime(2024,7,18,10,0,0)
t2 = UnixTime(2024,7,18,10,0,10)
p = Millisecond(100)
collect(t1:p:t2)
```

This commit fixes that.