### PR TITLE
Makie extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,18 +5,19 @@ version = "1.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
+Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [extensions]
-UnixTimesMakieExt = ["Makie", "MakieCore"]
+UnixTimesMakieExt = ["Makie", "Observables"]
 UnixTimesTimeZonesExt = "TimeZones"
 
 [compat]
+Makie = "0.22"
+Observables = "0.5"
 TimeZones = "1"
 julia = "1.9"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnixTimes"
 uuid = "ab1a18e7-b408-4913-896c-624bb82ed7f4"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,16 @@ version = "1.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+
+[weakdeps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+
+[extensions]
+UnixTimesMakieExt = ["Makie", "MakieCore"]
+UnixTimesTimeZonesExt = "TimeZones"
 
 [compat]
 TimeZones = "1"
@@ -16,9 +26,3 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [targets]
 test = ["Test", "TimeZones"]
-
-[weakdeps]
-TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-
-[extensions]
-UnixTimesTimeZonesExt = "TimeZones"

--- a/ext/UnixTimesMakieExt.jl
+++ b/ext/UnixTimesMakieExt.jl
@@ -1,0 +1,40 @@
+module UnixTimesMakieExt
+
+using UnixTimes
+using Makie
+using MakieCore
+using PlotUtils
+using Dates
+
+struct UnixTimeConversion <: Makie.AbstractDimConversion end
+
+Makie.needs_tick_update_observable(conversion::UnixTimeConversion) = nothing
+
+MakieCore.should_dim_convert(::Type{UnixTime}) = true
+
+Makie.create_dim_conversion(::Type{UnixTime}) = UnixTimeConversion()
+
+Makie.convert_dim_value(conversion::UnixTimeConversion, value::UnixTime) = Dates.value(value)
+Makie.convert_dim_value(conversion::UnixTimeConversion, values::AbstractArray) = Dates.value.(values)
+
+function Makie.convert_dim_observable(conversion::UnixTimeConversion, values::Observable, deregister)
+    result = map(values) do vs
+        Dates.value.(vs)
+    end
+    append!(deregister, result.inputs)
+    result
+end
+
+function Makie.get_ticks(conversion::UnixTimeConversion, ticks, scale, formatter, vmin, vmax)
+    # TODO: proper ticks for UnixTime
+    # Main.@infiltrate
+    # conversion, dates = PlotUtils.optimize_datetime_ticks(vmin, vmax; k_min=2, k_max=3)
+    tickvalues = Makie.get_tickvalues(formatter, scale, vmin, vmax)
+    dates = number_to_unixtime.(round.(Int64, tickvalues))
+    Main.@infiltrate
+    tickvalues, string.(dates)
+end
+
+number_to_unixtime(i) = UnixTime(Dates.UTInstant{Nanosecond}(Nanosecond(round(Int64, Float64(i)))))  # TODO: what type is i?
+
+end

--- a/ext/UnixTimesMakieExt.jl
+++ b/ext/UnixTimesMakieExt.jl
@@ -2,39 +2,46 @@ module UnixTimesMakieExt
 
 using UnixTimes
 using Makie
-using MakieCore
-using PlotUtils
+using Observables
 using Dates
 
-struct UnixTimeConversion <: Makie.AbstractDimConversion end
+struct UnixTimeConversion <: Makie.AbstractDimConversion
+    custom_epoch::Observable{UnixTime}
+    function UnixTimeConversion(custom_epoch=UnixTime(Date(2025, 01, 01)))
+        new(Observable{UnixTime}(custom_epoch; ignore_equal_values=true))
+    end
+end
+
+function number_to_unixtime(conversion::UnixTimeConversion, i)
+    Nanosecond(round(Int64, Float64(i))) + conversion.custom_epoch[]
+end
 
 Makie.needs_tick_update_observable(conversion::UnixTimeConversion) = nothing
 
-MakieCore.should_dim_convert(::Type{UnixTime}) = true
+Makie.MakieCore.should_dim_convert(::Type{UnixTime}) = true
 
 Makie.create_dim_conversion(::Type{UnixTime}) = UnixTimeConversion()
 
-Makie.convert_dim_value(conversion::UnixTimeConversion, value::UnixTime) = Dates.value(value)
-Makie.convert_dim_value(conversion::UnixTimeConversion, values::AbstractArray) = Dates.value.(values)
+function Makie.convert_dim_value(conversion::UnixTimeConversion, value::UnixTime)
+    Dates.value(value - conversion.custom_epoch[])
+end
+function Makie.convert_dim_value(conversion::UnixTimeConversion, values::AbstractArray{UnixTime})
+    Dates.value.(values .- conversion.custom_epoch[])
+end
 
 function Makie.convert_dim_observable(conversion::UnixTimeConversion, values::Observable, deregister)
-    result = map(values) do vs
-        Dates.value.(vs)
+    conversion.custom_epoch[] = min(conversion.custom_epoch[], first(values[]))
+    result = map(values, conversion.custom_epoch) do vs, ep
+        Dates.value.(vs .- ep)
     end
     append!(deregister, result.inputs)
     result
 end
 
 function Makie.get_ticks(conversion::UnixTimeConversion, ticks, scale, formatter, vmin, vmax)
-    # TODO: proper ticks for UnixTime
-    # Main.@infiltrate
-    # conversion, dates = PlotUtils.optimize_datetime_ticks(vmin, vmax; k_min=2, k_max=3)
     tickvalues = Makie.get_tickvalues(formatter, scale, vmin, vmax)
-    dates = number_to_unixtime.(round.(Int64, tickvalues))
-    Main.@infiltrate
+    dates = number_to_unixtime.(Ref(conversion), tickvalues)
     tickvalues, string.(dates)
 end
-
-number_to_unixtime(i) = UnixTime(Dates.UTInstant{Nanosecond}(Nanosecond(round(Int64, Float64(i)))))  # TODO: what type is i?
 
 end

--- a/ext/UnixTimesMakieExt.jl
+++ b/ext/UnixTimesMakieExt.jl
@@ -30,7 +30,7 @@ function Makie.convert_dim_value(conversion::UnixTimeConversion, values::Abstrac
 end
 
 function Makie.convert_dim_observable(conversion::UnixTimeConversion, values::Observable, deregister)
-    conversion.custom_epoch[] = min(conversion.custom_epoch[], first(values[]))
+    conversion.custom_epoch[] = max(conversion.custom_epoch[], last(values[]))
     result = map(values, conversion.custom_epoch) do vs, ep
         Dates.value.(vs .- ep)
     end

--- a/src/UnixTimes.jl
+++ b/src/UnixTimes.jl
@@ -54,10 +54,7 @@ Dates.Time(x::UnixTime) = Time(Nanosecond(Dates.value(x)))
 
 Base.convert(::Type{DateTime}, x::UnixTime) = DateTime(x)
 
-function UnixTime(x::DateTime)
-    instant_ns = (Dates.value(x) - Dates.UNIXEPOCH) * 1_000_000
-    UnixTime(Dates.UTInstant(Nanosecond(instant_ns)))
-end
+UnixTime(x::Dates.TimeType) = convert(UnixTime, x)
 
 UnixTime(x::Date) = UnixTime(DateTime(x))
 UnixTime(x::Date, y::Time) =
@@ -76,7 +73,10 @@ function UnixTime(s::AbstractString)
     end
 end
 
-Base.convert(::Type{UnixTime}, x::DateTime) = UnixTime(x)
+function Base.convert(::Type{UnixTime}, x::DateTime)
+    instant_ns = (Dates.value(x) - Dates.UNIXEPOCH) * 1_000_000
+    UnixTime(Dates.UTInstant(Nanosecond(instant_ns)))
+end
 
 function Base.show(io::IO, x::UnixTime)
     xdt = convert(DateTime, x)
@@ -94,7 +94,7 @@ function Base.floor(x::UnixTime, p::Union{DatePeriod, TimePeriod})
     convert(UnixTime, floor(convert(DateTime, x), p))
 end
 
-Dates.guess(a::UnixTime, b::UnixTime, c) = Dates.guess(DateTime(a), DateTime(b), c)
+Dates.guess(a::UnixTime, b::UnixTime, c) = (Dates.value(b) - Dates.value(a)) ÷ Dates.tons(c)
 
 Dates.default_format(::Type{UnixTime}) = nothing
 Dates.format(x::UnixTime, fmt::Nothing) = string(x)


### PR DESCRIPTION
Adds support for plotting UnixTime axes in Makie.

As far as I can tell, Makie plots everything as `Float64`, which will lose precision when plotting large timestamps. So, the conversion implemented here uses an offset from the last plotted UnixTime, meaning that plotting a single day should have full precision. Plotting multiple days will still inevitably lose precision further back in time.