### PR TITLE
Fix makie 0.24

### DIFF
--- a/ext/UnixTimesMakieExt.jl
+++ b/ext/UnixTimesMakieExt.jl
@@ -15,6 +15,9 @@ end
 function number_to_unixtime(conversion::UnixTimeConversion, i)
     Nanosecond(round(Int64, Float64(i))) + conversion.custom_epoch[]
 end
+function unixtime_to_number(conversion::UnixTimeConversion, value::UnixTime)
+    Dates.value(value - conversion.custom_epoch[])
+end
 
 Makie.expand_dimensions(::PointBased, y::AbstractVector{<:UnixTime}) = (keys(y), y)
 
@@ -25,13 +28,13 @@ Makie.should_dim_convert(::Type{UnixTime}) = true
 Makie.create_dim_conversion(::Type{UnixTime}) = UnixTimeConversion()
 
 function Makie.convert_dim_value(conversion::UnixTimeConversion, value::UnixTime)
-    Dates.value(value - conversion.custom_epoch[])
+    unixtime_to_number(conversion, value)
 end
 function Makie.convert_dim_value(conversion::UnixTimeConversion, values::AbstractArray{UnixTime})
-    Dates.value.(values .- conversion.custom_epoch[])
+    unixtime_to_number.(tuple(conversion), value)
 end
 function Makie.convert_dim_value(conversion::UnixTimeConversion, attr, values, prev_values)
-    Dates.value.(values .- conversion.custom_epoch[])
+    unixtime_to_number.(tuple(conversion), value)
 end
 
 function Makie.convert_dim_observable(conversion::UnixTimeConversion, values::Observable, deregister)

--- a/ext/UnixTimesMakieExt.jl
+++ b/ext/UnixTimesMakieExt.jl
@@ -21,7 +21,7 @@ end
 
 Makie.expand_dimensions(::PointBased, y::AbstractVector{<:UnixTime}) = (keys(y), y)
 
-Makie.needs_tick_update_observable(conversion::UnixTimeConversion) = nothing
+Makie.needs_tick_update_observable(conversion::UnixTimeConversion) = conversion.custom_epoch
 
 Makie.should_dim_convert(::Type{UnixTime}) = true
 

--- a/ext/UnixTimesMakieExt.jl
+++ b/ext/UnixTimesMakieExt.jl
@@ -6,15 +6,17 @@ using Observables
 using Dates
 
 struct UnixTimeConversion <: Makie.AbstractDimConversion
-    custom_epoch::Observable{Union{Nothing, UnixTime}}
-    function UnixTimeConversion(custom_epoch = nothing)
-        new(Observable{Union{Nothing, UnixTime}}(custom_epoch; ignore_equal_values=true))
+    custom_epoch::Observable{UnixTime}
+    function UnixTimeConversion(custom_epoch = UNIX_EPOCH)
+        new(Observable{UnixTime}(custom_epoch; ignore_equal_values=true))
     end
 end
 
 function number_to_unixtime(conversion::UnixTimeConversion, i)
-    Nanosecond(round(Int64, Float64(i))) + something(conversion.custom_epoch[], UNIX_EPOCH)
+    Nanosecond(round(Int64, Float64(i))) + conversion.custom_epoch[]
 end
+
+Makie.expand_dimensions(::PointBased, y::AbstractVector{<:UnixTime}) = (keys(y), y)
 
 Makie.needs_tick_update_observable(conversion::UnixTimeConversion) = nothing
 
@@ -23,19 +25,18 @@ Makie.should_dim_convert(::Type{UnixTime}) = true
 Makie.create_dim_conversion(::Type{UnixTime}) = UnixTimeConversion()
 
 function Makie.convert_dim_value(conversion::UnixTimeConversion, value::UnixTime)
-    Dates.value(value - something(conversion.custom_epoch[], UNIX_EPOCH))
+    Dates.value(value - conversion.custom_epoch[])
 end
 function Makie.convert_dim_value(conversion::UnixTimeConversion, values::AbstractArray{UnixTime})
-    Dates.value.(values .- something(conversion.custom_epoch[], UNIX_EPOCH))
+    Dates.value.(values .- conversion.custom_epoch[])
+end
+function Makie.convert_dim_value(conversion::UnixTimeConversion, attr, values, prev_values)
+    Dates.value.(values .- conversion.custom_epoch[])
 end
 
 function Makie.convert_dim_observable(conversion::UnixTimeConversion, values::Observable, deregister)
-    if conversion.custom_epoch[] === nothing
-        conversion.custom_epoch[] = last(values[])
-    end
-
     result = map(values, conversion.custom_epoch) do vs, ep
-        Dates.value.(vs .- something(ep, UNIX_EPOCH))
+        Dates.value.(vs .- ep)
     end
     append!(deregister, result.inputs)
     result


### PR DESCRIPTION
This PR does two things for the MakieExt:

1. Fixes the issue raised here: https://github.com/ancapdev/UnixTimes.jl/pull/15#issuecomment-3094549477
2. Defaults the `custom_epoch` used for the conversion to `UNIX_EPOCH`. This is because the current behaviour (picking the custom epoch to be the last plotted point in the axis) causes multiple axes in the same figure to be misaligned. It is still possible to set a custom epoch for higher precision on recent dates with: 
```
fap = Makie.lines(times, data)

fap.axis.dim1_conversion[].custom_epoch[] = unix_now()
reset_limits!(fap.axis)
```
(Unfortunately, constructing the UnixTimeConversion directly to pass to the axis requires the rather ugly `Base.get_extension(UnixTimes, :UnixTimesMakieExt).UnixTimeConversion`, as it isn't exported by UnixTimes.)

Tested on `Makie@{0.22, 0.23, 0.24}`

@JoaoAparicio